### PR TITLE
Fix notification grouping function sometimes returning a single notif…

### DIFF
--- a/app/javascript/flavours/glitch/features/notifications/index.js
+++ b/app/javascript/flavours/glitch/features/notifications/index.js
@@ -248,7 +248,7 @@ class Notifications extends React.PureComponent {
         groupedNotifications.push(newNotif);
       }
     }
-    return groupedNotifications.length === 1 ? groupedNotifications[0] : ImmutableList(groupedNotifications);
+    return ImmutableList(groupedNotifications);
   }
 
   render () {


### PR DESCRIPTION
…ication element, instead of a list, which would confuse the .map() function (item.get() is not a function)